### PR TITLE
Suppression de package-lock.json de .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
-package-lock.json
 README_fr.md


### PR DESCRIPTION
Le fait de mettre package-lock.json accélère npm install.